### PR TITLE
Fiks logging

### DIFF
--- a/src/main/java/no/nav/tag/tilsagnsbrev/integrasjon/PdfGenService.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/integrasjon/PdfGenService.java
@@ -33,8 +33,9 @@ public class PdfGenService {
 
     public void tilsagnsbrevTilPdfBytes(TilsagnUnderBehandling tilsagnUnderBehandling, String pdfJson) {
         Tilsagn tilsagn = tilsagnUnderBehandling.getTilsagn();
-        log.info("Oppretter pdf av tilsagnsbrev med tiltakskode {} for bedrift {}", tilsagn.getTiltakArrangor().getOrgNummer());
-        URI uri = pdfTemplateURI.getTemplateURI(tilsagn.getTiltakKode());
+        String tiltakKode = tilsagn.getTiltakKode();
+        log.info("Oppretter pdf av tilsagnsbrev med tiltakskode {} for bedrift {}", tiltakKode, tilsagn.getTiltakArrangor().getOrgNummer());
+        URI uri = pdfTemplateURI.getTemplateURI(tiltakKode);
         tilsagnUnderBehandling.setPdf(hentPdf(pdfJson, uri));
     }
 


### PR DESCRIPTION
Logg-linjen forsøkte tilsynelatende å logge både tiltakskode og org-nummer, men bare orgnummer var med som parameter. Jeg la til tiltakskoden også.