### PR TITLE
Enhetlig behandling av tilsagn ved førstegangskjøring og rekjøring

### DIFF
--- a/src/main/java/no/nav/tag/tilsagnsbrev/behandler/Oppgaver.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/behandler/Oppgaver.java
@@ -6,7 +6,7 @@ import no.nav.tag.tilsagnsbrev.dto.journalpost.Journalpost;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
 import no.nav.tag.tilsagnsbrev.exception.DataException;
 import no.nav.tag.tilsagnsbrev.exception.SystemException;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnBehandler;
 import no.nav.tag.tilsagnsbrev.integrasjon.AltInnService;
 import no.nav.tag.tilsagnsbrev.integrasjon.JoarkService;
 import no.nav.tag.tilsagnsbrev.integrasjon.PdfGenService;
@@ -39,7 +39,7 @@ public class Oppgaver {
     private TilsagnTilAltinnMapper tilsagnTilAltinnMapper;
 
     @Autowired
-    private FeiletTilsagnBehandler feiletTilsagnBehandler;
+    private TilsagnBehandler tilsagnBehandler;
 
     private void opprettPdfDok(TilsagnUnderBehandling tilsagnUnderBehandling){
         String pdfJson = tilsagnJsonMapper.opprettPdfJson(tilsagnUnderBehandling);
@@ -86,7 +86,7 @@ public class Oppgaver {
     }
 
     public void oppdaterFeiletTilsagn(TilsagnUnderBehandling tilsagnUnderBehandling, Exception e) {
-        if (!feiletTilsagnBehandler.lagreEllerOppdaterFeil(tilsagnUnderBehandling, e)) {
+        if (!tilsagnBehandler.lagreEllerOppdaterFeil(tilsagnUnderBehandling, e)) {
             log.error("Feil ble ikke lagret! Melding: {}", tilsagnUnderBehandling.getJson(), e.getMessage());
         }
     }
@@ -107,7 +107,7 @@ public class Oppgaver {
                 sendTilAltinn(tilsagnUnderBehandling);
             }
             tilsagnUnderBehandling.setBehandlet(true);
-            feiletTilsagnBehandler.lagreStatus(tilsagnUnderBehandling);
+            tilsagnBehandler.lagreStatus(tilsagnUnderBehandling);
             log.info("Fullført behandling av tilsagnsbrev {}.", tilsagnUnderBehandling.getTilsagnsbrevId());
         } catch (Exception e) {
             oppdaterFeiletTilsagn(tilsagnUnderBehandling, e);

--- a/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsess.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsess.java
@@ -1,11 +1,10 @@
 package no.nav.tag.tilsagnsbrev.behandler;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
 import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
-import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -19,40 +18,14 @@ public class TilsagnRetryProsess {
     @Autowired
     FeiletTilsagnBehandler feiletTilsagnBehandler;
 
-    @Autowired
-    TilsagnJsonMapper tilsagnJsonMapper;
-
 //    @Scheduled(cron = "${tilsagnsbrev.retry.cron}")       //TODO Disablet ifbm. test av prodsetting
     public void finnOgRekjoerFeiletTilsagn() {
         log.info("Starter retry");
         feiletTilsagnBehandler.hentAlleTilRekjoring()
                 .forEach(feiletTilsagnsbrev -> {
-                    try {
-                        log.info("Tilsagnsbrev {} retry no. {}", feiletTilsagnsbrev.getTilsagnsbrevId(), feiletTilsagnsbrev.getRetry()); //TODO ordne på telling av retries
-                        rekjoerTilsagn(feiletTilsagnsbrev);
-                        log.info("Fullført retry på tilsagnsbrev {}.", feiletTilsagnsbrev.getTilsagnsbrevId());
-                    } catch (Exception e) {
-                        oppgaver.oppdaterFeiletTilsagn(feiletTilsagnsbrev, e);
-                    }
+                    log.info("Tilsagnsbrev {} retry no. {}", feiletTilsagnsbrev.getTilsagnsbrevId(), feiletTilsagnsbrev.getRetry()); //TODO ordne på telling av retries
+                    oppgaver.utfoerOppgaver(feiletTilsagnsbrev);
                 });
     }
 
-    private void rekjoerTilsagn(TilsagnUnderBehandling tilsagnUnderBehandling) {
-
-        tilsagnJsonMapper.opprettTilsagn(tilsagnUnderBehandling);
-
-        if(tilsagnUnderBehandling.manglerPdf()) {
-            oppgaver.opprettPdfDok(tilsagnUnderBehandling);
-        }
-
-        if (tilsagnUnderBehandling.skaljournalfoeres()) {
-            oppgaver.journalfoerTilsagnsbrev(tilsagnUnderBehandling);
-        }
-
-        if (tilsagnUnderBehandling.skalTilAltinn()) {
-            oppgaver.sendTilAltinn(tilsagnUnderBehandling);
-        }
-        tilsagnUnderBehandling.setBehandlet(true);
-        feiletTilsagnBehandler.oppdater(tilsagnUnderBehandling);
-    }
 }

--- a/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsess.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsess.java
@@ -1,7 +1,7 @@
 package no.nav.tag.tilsagnsbrev.behandler;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnBehandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,12 +16,12 @@ public class TilsagnRetryProsess {
     Oppgaver oppgaver;
 
     @Autowired
-    FeiletTilsagnBehandler feiletTilsagnBehandler;
+    private TilsagnBehandler tilsagnBehandler;
 
 //    @Scheduled(cron = "${tilsagnsbrev.retry.cron}")       //TODO Disablet ifbm. test av prodsetting
     public void finnOgRekjoerFeiletTilsagn() {
         log.info("Starter retry");
-        feiletTilsagnBehandler.hentAlleTilRekjoring()
+        tilsagnBehandler.hentAlleTilRekjoring()
                 .forEach(feiletTilsagnsbrev -> {
                     log.info("Tilsagnsbrev {} retry no. {}", feiletTilsagnsbrev.getTilsagnsbrevId(), feiletTilsagnsbrev.getRetry()); //TODO ordne på telling av retries
                     oppgaver.utfoerOppgaver(feiletTilsagnsbrev);

--- a/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandler.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandler.java
@@ -34,16 +34,7 @@ public class TilsagnsbrevBehandler {
         if(!lagreNyMeldingILogg(tilsagnUnderBehandling)) {
             return;
         }
-
-        tilsagnJsonMapper.opprettTilsagn(tilsagnUnderBehandling);
-        oppgaver.opprettPdfDok(tilsagnUnderBehandling);
-
-        try {
-            oppgaver.journalfoerTilsagnsbrev(tilsagnUnderBehandling);
-        } catch (Exception e) {
-            oppgaver.oppdaterFeiletTilsagn(tilsagnUnderBehandling, e);
-        }
-        oppgaver.sendTilAltinn(tilsagnUnderBehandling);
+        oppgaver.utfoerOppgaver(tilsagnUnderBehandling);
     }
 
     private boolean lagreNyMeldingILogg(TilsagnUnderBehandling tilsagnUnderBehandling){

--- a/src/main/java/no/nav/tag/tilsagnsbrev/feilet/FeiletTilsagnBehandler.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/feilet/FeiletTilsagnBehandler.java
@@ -2,13 +2,11 @@ package no.nav.tag.tilsagnsbrev.feilet;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
-import no.nav.tag.tilsagnsbrev.exception.DataException;
 import no.nav.tag.tilsagnsbrev.exception.TilsagnException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -16,7 +14,7 @@ import java.util.stream.Collectors;
 public class FeiletTilsagnBehandler {
 
     @Autowired
-    FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
+    private FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
 
     public List<TilsagnUnderBehandling> hentAlleTilRekjoring() {
         return feiletTilsagnsbrevRepository.findAll().stream().filter(tub -> !tub.isBehandlet()).filter(TilsagnUnderBehandling::skalRekjoeres).collect(Collectors.toList());
@@ -32,24 +30,17 @@ public class FeiletTilsagnBehandler {
         return false;
     }
 
-    public boolean oppdater(TilsagnUnderBehandling oppdatertTilsagn) {
-        return oppdaterFeilet(oppdatertTilsagn, Optional.empty());
-    }
-
-    private boolean oppdaterFeilet(TilsagnUnderBehandling oppdatertTilsagn, Optional<Exception> optEx) {
-        return feiletTilsagnsbrevRepository.findById(oppdatertTilsagn.getCid())
-                .map(hentet -> hentet.oppdater(oppdatertTilsagn))
-                .map(oppdatert -> lagreEllerOppdater(oppdatert))
-                .orElseThrow(() -> new RuntimeException("Fant ikke feilet tilsagnsbrev i database: " + oppdatertTilsagn.getCid()));
+    public boolean lagreStatus(TilsagnUnderBehandling oppdatertTilsagn) {
+        return lagreEllerOppdater(oppdatertTilsagn);
     }
 
     private boolean lagreEllerOppdater(TilsagnUnderBehandling tilsagnUnderBehandling) {
         try {
-            TilsagnUnderBehandling oppdatert = feiletTilsagnsbrevRepository
+            TilsagnUnderBehandling oppdatertTilsagnUnderBehandling = feiletTilsagnsbrevRepository
                     .findById(tilsagnUnderBehandling.getCid())
                     .map(tub -> tub.oppdater(tilsagnUnderBehandling))
                     .orElse(tilsagnUnderBehandling);
-            feiletTilsagnsbrevRepository.save(oppdatert);
+            feiletTilsagnsbrevRepository.save(oppdatertTilsagnUnderBehandling);
             return true;
         } catch (Exception e) {
             log.error("Feil ved lagring av tilsagnsfeil! Tilsagn: {}", tilsagnUnderBehandling.getJson(), e);

--- a/src/main/java/no/nav/tag/tilsagnsbrev/feilet/TilsagnBehandler.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/feilet/TilsagnBehandler.java
@@ -11,13 +11,13 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-public class FeiletTilsagnBehandler {
+public class TilsagnBehandler {
 
     @Autowired
-    private FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
+    private TilsagnsbrevRepository tilsagnsbrevRepository;
 
     public List<TilsagnUnderBehandling> hentAlleTilRekjoring() {
-        return feiletTilsagnsbrevRepository.findAll().stream().filter(tub -> !tub.isBehandlet()).filter(TilsagnUnderBehandling::skalRekjoeres).collect(Collectors.toList());
+        return tilsagnsbrevRepository.findAll().stream().filter(tub -> !tub.isBehandlet()).filter(TilsagnUnderBehandling::skalRekjoeres).collect(Collectors.toList());
     }
 
     public boolean lagreEllerOppdaterFeil(TilsagnUnderBehandling tilsagnUnderBehandling, Exception e) {
@@ -36,11 +36,11 @@ public class FeiletTilsagnBehandler {
 
     private boolean lagreEllerOppdater(TilsagnUnderBehandling tilsagnUnderBehandling) {
         try {
-            TilsagnUnderBehandling oppdatertTilsagnUnderBehandling = feiletTilsagnsbrevRepository
+            TilsagnUnderBehandling oppdatertTilsagnUnderBehandling = tilsagnsbrevRepository
                     .findById(tilsagnUnderBehandling.getCid())
                     .map(tub -> tub.oppdater(tilsagnUnderBehandling))
                     .orElse(tilsagnUnderBehandling);
-            feiletTilsagnsbrevRepository.save(oppdatertTilsagnUnderBehandling);
+            tilsagnsbrevRepository.save(oppdatertTilsagnUnderBehandling);
             return true;
         } catch (Exception e) {
             log.error("Feil ved lagring av tilsagnsfeil! Tilsagn: {}", tilsagnUnderBehandling.getJson(), e);
@@ -50,7 +50,7 @@ public class FeiletTilsagnBehandler {
 
     public void slettTilsagn(TilsagnUnderBehandling tilsagnUnderBehandling) {
         log.info("Fjerner tilsagn fra database: {}", tilsagnUnderBehandling.getTilsagn());
-        feiletTilsagnsbrevRepository.delete(tilsagnUnderBehandling);
+        tilsagnsbrevRepository.delete(tilsagnUnderBehandling);
     }
 }
 

--- a/src/main/java/no/nav/tag/tilsagnsbrev/feilet/TilsagnsbrevRepository.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/feilet/TilsagnsbrevRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.List;
 import java.util.UUID;
 
-public interface FeiletTilsagnsbrevRepository extends CrudRepository<TilsagnUnderBehandling, UUID> {
+public interface TilsagnsbrevRepository extends CrudRepository<TilsagnUnderBehandling, UUID> {
 
     @Override
     List<TilsagnUnderBehandling> findAll();

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/OppgaverTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/OppgaverTest.java
@@ -17,7 +17,7 @@ import no.nav.tag.tilsagnsbrev.dto.journalpost.Journalpost;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
 import no.nav.tag.tilsagnsbrev.exception.DataException;
 import no.nav.tag.tilsagnsbrev.exception.TilsagnException;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnBehandler;
 import no.nav.tag.tilsagnsbrev.integrasjon.AltInnService;
 import no.nav.tag.tilsagnsbrev.integrasjon.JoarkService;
 import no.nav.tag.tilsagnsbrev.integrasjon.PdfGenService;
@@ -32,7 +32,7 @@ public class OppgaverTest {
     private TilsagnJsonMapper tilsagnJsonMapper;
 
     @Mock
-    private FeiletTilsagnBehandler feiletTilsagnBehandler;
+    private TilsagnBehandler tilsagnBehandler;
 
     @Mock
     private PdfGenService pdfService;
@@ -77,7 +77,7 @@ public class OppgaverTest {
         verifyPdfDokOpprettet();
         verifyJournalforing();
         verifySendTilAltinn();
-        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+        verify(tilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
     }
 
     private void verifyPdfDokOpprettet() {
@@ -103,7 +103,7 @@ public class OppgaverTest {
 
         verifyJournalforing();
         verifyNoInteractions(pdfService, altInnService);
-        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+        verify(tilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
     }
 
 
@@ -115,7 +115,7 @@ public class OppgaverTest {
         oppgaver.utfoerOppgaver(tub);
         verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
         verifySendTilAltinn();
-        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+        verify(tilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
     }
     
     @Test
@@ -128,7 +128,7 @@ public class OppgaverTest {
 
         verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
         verifyNoInteractions(pdfService, altInnService, tilsagnJournalpostMapper, joarkService);
-        verify(feiletTilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
+        verify(tilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
     }
 
     @Test
@@ -142,7 +142,7 @@ public class OppgaverTest {
         verify(tilsagnJsonMapper, times(1)).opprettTilsagn(tub);
         verify(tilsagnJsonMapper, times(1)).opprettPdfJson(tub);
         verifyNoInteractions(pdfService, altInnService, tilsagnJournalpostMapper, joarkService);
-        verify(feiletTilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
+        verify(tilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
     }
 
 }

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/OppgaverTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/OppgaverTest.java
@@ -1,0 +1,148 @@
+package no.nav.tag.tilsagnsbrev.behandler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import no.altinn.services.serviceengine.correspondence._2009._10.InsertCorrespondenceBasicV2;
+import no.nav.tag.tilsagnsbrev.Testdata;
+import no.nav.tag.tilsagnsbrev.dto.journalpost.Journalpost;
+import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
+import no.nav.tag.tilsagnsbrev.exception.DataException;
+import no.nav.tag.tilsagnsbrev.exception.TilsagnException;
+import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
+import no.nav.tag.tilsagnsbrev.integrasjon.AltInnService;
+import no.nav.tag.tilsagnsbrev.integrasjon.JoarkService;
+import no.nav.tag.tilsagnsbrev.integrasjon.PdfGenService;
+import no.nav.tag.tilsagnsbrev.mapper.TilsagnJournalpostMapper;
+import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
+import no.nav.tag.tilsagnsbrev.mapper.TilsagnTilAltinnMapper;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OppgaverTest {
+
+    @Mock
+    private TilsagnJsonMapper tilsagnJsonMapper;
+
+    @Mock
+    private FeiletTilsagnBehandler feiletTilsagnBehandler;
+
+    @Mock
+    private PdfGenService pdfService;
+
+    @Mock
+    private JoarkService joarkService;
+
+    @Mock
+    private AltInnService altInnService;
+
+    @Mock
+    private TilsagnJournalpostMapper tilsagnJournalpostMapper;
+
+    @Mock
+    private TilsagnTilAltinnMapper tilsagnTilAltinnMapper;
+
+    @InjectMocks
+    private Oppgaver oppgaver;
+
+    private static final String PDF_JSON = "pdfJson";
+    private static final byte[] PDF_BYTEARRAY = "pdf".getBytes();
+    private static final String TILSAGN_DATA = Testdata.hentFilString("TILSAGN_DATA.json");
+    private static final Journalpost JOURNALPOST = mock(Journalpost.class);
+    private static final InsertCorrespondenceBasicV2 ALTINN_WS_REQUEST = mock(InsertCorrespondenceBasicV2.class);
+
+    @Before
+    public void setUp() {
+        
+        when(tilsagnJsonMapper.opprettPdfJson(any(TilsagnUnderBehandling.class))).thenReturn(PDF_JSON);
+        when(tilsagnJournalpostMapper.tilsagnTilJournalpost(any(TilsagnUnderBehandling.class))).thenReturn(JOURNALPOST);
+        
+    }
+    
+    @Test
+    public void behandlerTilsagnEtterEnManuellBehandlingAvArenaMappingFeil() {
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().build();
+        when(tilsagnTilAltinnMapper.tilAltinnMelding(null, null)).thenReturn(ALTINN_WS_REQUEST);
+
+        oppgaver.utfoerOppgaver(tub);
+        
+        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(eq(tub));
+        verifyPdfDokOpprettet();
+        verifyJournalforing();
+        verifySendTilAltinn();
+        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+    }
+
+    private void verifyPdfDokOpprettet() {
+        verify(tilsagnJsonMapper, times(1)).opprettPdfJson(any(TilsagnUnderBehandling.class));
+        verify(pdfService, times(1)).tilsagnsbrevTilPdfBytes(any(TilsagnUnderBehandling.class), eq(PDF_JSON));
+    }
+    
+    private void verifyJournalforing() {
+        verify(tilsagnJournalpostMapper, times(1)).tilsagnTilJournalpost(any(TilsagnUnderBehandling.class));
+        verify(joarkService, times(1)).sendJournalpost(JOURNALPOST);
+    }
+    
+    private void verifySendTilAltinn() {
+        verify(altInnService, times(1)).sendTilsagnsbrev(ALTINN_WS_REQUEST);
+    }
+
+    @Test
+    public void behandlerTilsagnEtterFeiletJournalforing() {
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().json(TILSAGN_DATA).pdf(PDF_BYTEARRAY).tilsagnsbrevId(1).mappetFraArena(true).altinnReferanse(002).build();
+
+        oppgaver.utfoerOppgaver(tub);
+        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
+
+        verifyJournalforing();
+        verifyNoInteractions(pdfService, altInnService);
+        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+    }
+
+
+    @Test
+    public void behandlerTilsagnEtterFeiletAltinnSending() {
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().json(TILSAGN_DATA).pdf(PDF_BYTEARRAY).tilsagnsbrevId(1).mappetFraArena(true).journalpostId("1").build();
+        when(tilsagnTilAltinnMapper.tilAltinnMelding(null, PDF_BYTEARRAY)).thenReturn(ALTINN_WS_REQUEST);
+
+        oppgaver.utfoerOppgaver(tub);
+        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
+        verifySendTilAltinn();
+        verify(feiletTilsagnBehandler, times(1)).lagreStatus(any(TilsagnUnderBehandling.class));
+    }
+    
+    @Test
+    public void avbryterHvisOpprettTilsagnFeiler() {
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().build();
+
+        doThrow(DataException.class).when(tilsagnJsonMapper).opprettTilsagn(tub);
+        
+        oppgaver.utfoerOppgaver(tub);
+
+        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
+        verifyNoInteractions(pdfService, altInnService, tilsagnJournalpostMapper, joarkService);
+        verify(feiletTilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
+    }
+
+    @Test
+    public void avbryterHvisOpprettPdfDokFeiler() {
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().build();
+
+        when(tilsagnJsonMapper.opprettPdfJson(tub)).thenThrow(DataException.class);
+
+        oppgaver.utfoerOppgaver(tub);
+
+        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(tub);
+        verify(tilsagnJsonMapper, times(1)).opprettPdfJson(tub);
+        verifyNoInteractions(pdfService, altInnService, tilsagnJournalpostMapper, joarkService);
+        verify(feiletTilsagnBehandler, times(1)).lagreEllerOppdaterFeil(eq(tub), any(TilsagnException.class));
+    }
+
+}

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessIntTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessIntTest.java
@@ -2,8 +2,8 @@ package no.nav.tag.tilsagnsbrev.behandler;
 
 import no.nav.tag.tilsagnsbrev.Testdata;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnsbrevRepository;
 import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnsbrevRepository;
 import no.nav.tag.tilsagnsbrev.simulator.IntegrasjonerMockServer;
 import org.junit.After;
 import org.junit.Before;
@@ -35,7 +35,7 @@ public class TilsagnRetryProsessIntTest {
     private IntegrasjonerMockServer mockServer;
 
     @Autowired
-    private FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
+    private TilsagnsbrevRepository tilsagnsbrevRepository;
 
     @Autowired
     private TilsagnLoggRepository tilsagnLoggRepository;
@@ -57,7 +57,7 @@ public class TilsagnRetryProsessIntTest {
     @After
     public void tearDown() {
         mockServer.getServer().resetAll();
-        feiletTilsagnsbrevRepository.deleteAll();
+        tilsagnsbrevRepository.deleteAll();
     }
 
     @Test
@@ -67,11 +67,11 @@ public class TilsagnRetryProsessIntTest {
         TilsagnUnderBehandling tub1 = Testdata.tubBuilder().json(tilsagnData).mappetFraArena(false).cid(CID1).tilsagnsbrevId(1).opprettet(LocalDateTime.now()).build();
         TilsagnUnderBehandling tub2 = Testdata.tubBuilder().json(tilsagnData).mappetFraArena(true).pdf("pdf".getBytes()).altinnReferanse(1).cid(CID2).opprettet(LocalDateTime.now()).tilsagnsbrevId(2).build();
 
-        feiletTilsagnsbrevRepository.saveAll(Arrays.asList(tub1, tub2));
+        tilsagnsbrevRepository.saveAll(Arrays.asList(tub1, tub2));
 
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
 
-        List<TilsagnUnderBehandling> tubList = feiletTilsagnsbrevRepository.findAll();
+        List<TilsagnUnderBehandling> tubList = tilsagnsbrevRepository.findAll();
 
         assertEquals(2, tubList.size());
         assertTrue(tubList.stream().anyMatch(tub -> tub.getCid().equals(CID1)));
@@ -90,11 +90,11 @@ public class TilsagnRetryProsessIntTest {
     public void behandlerTilsagnEtterFeiletJournalforing() {
         final UUID CID = UUID.randomUUID();
         TilsagnUnderBehandling feilet = Testdata.tubBuilder().cid(CID).json(tilsagnData).pdf("pdf".getBytes()).tilsagnsbrevId(1).mappetFraArena(true).altinnReferanse(002).build();
-        feiletTilsagnsbrevRepository.save(feilet);
+        tilsagnsbrevRepository.save(feilet);
 
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
 
-        Optional<TilsagnUnderBehandling> opt = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> opt = tilsagnsbrevRepository.findById(CID);
         assertTrue("Tilsagn ikke i database", opt.isPresent());
 
         TilsagnUnderBehandling tub = opt.get();
@@ -110,11 +110,11 @@ public class TilsagnRetryProsessIntTest {
     public void behandlerTilsagnEtterFeiletAltinnSending() {
         final UUID CID = UUID.randomUUID();
         TilsagnUnderBehandling feilet = Testdata.tubBuilder().cid(CID).json(tilsagnData).pdf("pdf".getBytes()).tilsagnsbrevId(1).mappetFraArena(true).journalpostId("1234").build();
-        feiletTilsagnsbrevRepository.save(feilet);
+        tilsagnsbrevRepository.save(feilet);
 
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
 
-        Optional<TilsagnUnderBehandling> opt = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> opt = tilsagnsbrevRepository.findById(CID);
         assertTrue("Tilsagn ikke i database", opt.isPresent());
 
         TilsagnUnderBehandling tub = opt.get();
@@ -132,10 +132,10 @@ public class TilsagnRetryProsessIntTest {
         final UUID CID = UUID.randomUUID();
         TilsagnUnderBehandling feilet = Testdata.tubBuilder().retry(1).cid(CID).json(tilsagnData).tilsagnsbrevId(1).mappetFraArena(true).journalpostId("1234").build();
 
-        feiletTilsagnsbrevRepository.save(feilet);
+        tilsagnsbrevRepository.save(feilet);
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
 
-        Optional<TilsagnUnderBehandling> opt = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> opt = tilsagnsbrevRepository.findById(CID);
         assertTrue("Tilsagn ikke i database", opt.isPresent());
 
         TilsagnUnderBehandling tub = opt.get();

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessTest.java
@@ -1,10 +1,7 @@
 package no.nav.tag.tilsagnsbrev.behandler;
 
-import no.nav.tag.tilsagnsbrev.Testdata;
-import no.nav.tag.tilsagnsbrev.dto.ArenaMelding;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
 import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
-import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -13,7 +10,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -23,72 +19,18 @@ public class TilsagnRetryProsessTest {
     private Oppgaver oppgaver;
 
     @Mock
-    private TilsagnLoggRepository tilsagnLoggRepository;
-
-    @Mock
-    private TilsagnJsonMapper tilsagnJsonMapper;
-
-    @Mock
-    FeiletTilsagnBehandler feiletTilsagnBehandler;
+    private FeiletTilsagnBehandler feiletTilsagnBehandler;
 
     @InjectMocks
     private TilsagnRetryProsess tilsagnRetryProsess;
 
-    private final static String tilsagnData = Testdata.hentFilString("TILSAGN_DATA.json");
-    private final static ArenaMelding arenaMelding = Testdata.arenaMelding();
-
-
     @Test
-    public void behandlerTilsagnEtterEnManuellBehandlingAvArenaMappingFeil() {
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().arenaMelding(arenaMelding).build();
-        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tub));
-
+    public void behandlerTilsagnPaNytt() {
+        TilsagnUnderBehandling tilsagnUnderBehandling = new TilsagnUnderBehandling();
+        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tilsagnUnderBehandling));
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(eq(tub));
-        verify(tilsagnLoggRepository, never()).lagretIdHvisNyMelding(tub);
-        verify(oppgaver, times(1)).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(feiletTilsagnBehandler, times(1)).oppdater(any(TilsagnUnderBehandling.class));
+
+        verify(oppgaver, times(1)).utfoerOppgaver(tilsagnUnderBehandling);
     }
 
-    @Test
-    public void behandlerTilsagnEtterFeiletJournalforing() {
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().json(tilsagnData).pdf("pdf".getBytes()).tilsagnsbrevId(1).mappetFraArena(true).altinnReferanse(002).build();
-        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tub));
-
-        tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(feiletTilsagnBehandler, times(1)).oppdater(any(TilsagnUnderBehandling.class));
-    }
-
-
-    @Test
-    public void behandlerTilsagnEtterFeiletAltinnSending() {
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().json(tilsagnData).pdf("pdf".getBytes()).tilsagnsbrevId(1).mappetFraArena(true).journalpostId("1").build();
-        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tub));
-
-        tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(feiletTilsagnBehandler, times(1)).oppdater(any(TilsagnUnderBehandling.class));
-    }
-
-    @Test
-    public void feilerIgjenEtterFeiletAltinnSending() {
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().json(tilsagnData).pdf("pdf".getBytes()).mappetFraArena(true).tilsagnsbrevId(1).journalpostId("1").build();
-        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tub));
-
-        tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(feiletTilsagnBehandler, times(1)).oppdater(any(TilsagnUnderBehandling.class));
-    }
 }

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnRetryProsessTest.java
@@ -1,7 +1,7 @@
 package no.nav.tag.tilsagnsbrev.behandler;
 
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnBehandler;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnBehandler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -19,7 +19,7 @@ public class TilsagnRetryProsessTest {
     private Oppgaver oppgaver;
 
     @Mock
-    private FeiletTilsagnBehandler feiletTilsagnBehandler;
+    private TilsagnBehandler tilsagnBehandler;
 
     @InjectMocks
     private TilsagnRetryProsess tilsagnRetryProsess;
@@ -27,7 +27,7 @@ public class TilsagnRetryProsessTest {
     @Test
     public void behandlerTilsagnPaNytt() {
         TilsagnUnderBehandling tilsagnUnderBehandling = new TilsagnUnderBehandling();
-        when(feiletTilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tilsagnUnderBehandling));
+        when(tilsagnBehandler.hentAlleTilRekjoring()).thenReturn(Arrays.asList(tilsagnUnderBehandling));
         tilsagnRetryProsess.finnOgRekjoerFeiletTilsagn();
 
         verify(oppgaver, times(1)).utfoerOppgaver(tilsagnUnderBehandling);

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandlerIntTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandlerIntTest.java
@@ -3,8 +3,8 @@ package no.nav.tag.tilsagnsbrev.behandler;
 import no.nav.tag.tilsagnsbrev.Testdata;
 import no.nav.tag.tilsagnsbrev.dto.ArenaMelding;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnsbrevRepository;
 import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnsbrevRepository;
 import no.nav.tag.tilsagnsbrev.simulator.IntegrasjonerMockServer;
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +38,7 @@ public class TilsagnsbrevBehandlerIntTest {
     private TilsagnsbrevBehandler tilsagnsbrevbehandler;
 
     @Autowired
-    FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
+    private TilsagnsbrevRepository tilsagnsbrevRepository;
 
     @Autowired
     TilsagnLoggRepository tilsagnLoggRepository;
@@ -52,7 +52,7 @@ public class TilsagnsbrevBehandlerIntTest {
     @After
     public void tearDown() {
         mockServer.getServer().resetAll();
-        feiletTilsagnsbrevRepository.deleteAll();
+        tilsagnsbrevRepository.deleteAll();
         loggCrudRepository.deleteAll();
     }
 
@@ -86,7 +86,7 @@ public class TilsagnsbrevBehandlerIntTest {
 
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
 
-        Optional<TilsagnUnderBehandling> feilet = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> feilet = tilsagnsbrevRepository.findById(CID);
         assertTrue(feilet.isPresent());
         feilet.map(tub -> {
             assertFalse(tub.skalRekjoeres());
@@ -106,7 +106,7 @@ public class TilsagnsbrevBehandlerIntTest {
         TilsagnUnderBehandling tilsagnUnderBehandling = Testdata.tubBuilder().arenaMelding(arenaMelding).cid(CID).build();
 
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
-        Optional<TilsagnUnderBehandling> feilet = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> feilet = tilsagnsbrevRepository.findById(CID);
 
         assertTrue(feilet.isPresent());
         feilet.map(tub -> {
@@ -128,7 +128,7 @@ public class TilsagnsbrevBehandlerIntTest {
 
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
 
-        Optional<TilsagnUnderBehandling> feilet = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> feilet = tilsagnsbrevRepository.findById(CID);
         assertTrue(feilet.isPresent());
         feilet.map(tub -> {
             assertTrue(tub.skalRekjoeres());
@@ -148,7 +148,7 @@ public class TilsagnsbrevBehandlerIntTest {
 
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
 
-        Optional<TilsagnUnderBehandling> feilet = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> feilet = tilsagnsbrevRepository.findById(CID);
         assertTrue(feilet.isPresent());
         feilet.map(tub -> {
             assertTrue(tub.skalRekjoeres());
@@ -169,7 +169,7 @@ public class TilsagnsbrevBehandlerIntTest {
 
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
 
-        Optional<TilsagnUnderBehandling> feilet = feiletTilsagnsbrevRepository.findById(CID);
+        Optional<TilsagnUnderBehandling> feilet = tilsagnsbrevRepository.findById(CID);
         assertTrue(feilet.isPresent());
         feilet.map(tub -> {
             assertTrue(tub.skalRekjoeres());

--- a/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandlerTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/behandler/TilsagnsbrevBehandlerTest.java
@@ -1,11 +1,7 @@
 package no.nav.tag.tilsagnsbrev.behandler;
 
 import no.nav.tag.tilsagnsbrev.dto.ArenaMelding;
-import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.Tilsagn;
 import no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling;
-import no.nav.tag.tilsagnsbrev.exception.DataException;
-import no.nav.tag.tilsagnsbrev.exception.SystemException;
-import no.nav.tag.tilsagnsbrev.exception.TilsagnException;
 import no.nav.tag.tilsagnsbrev.mapper.TilsagnJsonMapper;
 import no.nav.tag.tilsagnsbrev.Testdata;
 import org.junit.Test;
@@ -13,8 +9,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
@@ -35,39 +29,13 @@ public class TilsagnsbrevBehandlerTest {
 
     @Test
     public void behandlerTilsagn() {
-        ArenaMelding arenaMelding = Testdata.arenaMelding();
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().arenaMelding(arenaMelding).build();
+        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().arenaMelding(Testdata.arenaMelding()).build();
 
         when(tilsagnLoggRepository.lagretIdHvisNyMelding(tub)).thenReturn(true);
         tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tub);
         verify(tilsagnJsonMapper, times(1)).pakkUtArenaMelding(tub);
-        verify(tilsagnLoggRepository, atLeastOnce()).lagretIdHvisNyMelding(tub);
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).sendTilAltinn(any(TilsagnUnderBehandling.class));
-    }
-
-    @Test
-    public void senderTilAltinnSelvOmJournalforingFeiler() {
-
-        final byte[] pdf = "pdf".getBytes();
-        String arenaMelding = Testdata.hentFilString("arenaMelding.json");
-        Tilsagn tilsagn = Testdata.tilsagnEnDeltaker();
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().cid(UUID.randomUUID()).tilsagn(tilsagn).json(arenaMelding).build();
-
-        doNothing().when(tilsagnJsonMapper).pakkUtArenaMelding(tub);
-
-        doNothing().when(tilsagnJsonMapper).opprettTilsagn(tub);
-        doNothing().when(oppgaver).opprettPdfDok(tub);
-        doThrow(SystemException.class).when(oppgaver).journalfoerTilsagnsbrev(tub);
-        doNothing().when(oppgaver).sendTilAltinn(tub);
-        when(tilsagnLoggRepository.lagretIdHvisNyMelding(any(TilsagnUnderBehandling.class))).thenReturn(true);
-
-        tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tub);
-        verify(oppgaver, times(1)).sendTilAltinn(tub);
-        verify(oppgaver, times(1)).oppdaterFeiletTilsagn(eq(tub), any(SystemException.class));
-        verify(tilsagnLoggRepository, times(1)).lagretIdHvisNyMelding(eq(tub));
+        verify(tilsagnLoggRepository, times(1)).lagretIdHvisNyMelding(tub);
+        verify(oppgaver, times(1)).utfoerOppgaver(tub);
     }
 
     @Test(expected = RuntimeException.class)
@@ -76,50 +44,14 @@ public class TilsagnsbrevBehandlerTest {
         TilsagnUnderBehandling tilsagnUnderBehandling = TilsagnUnderBehandling.builder().arenaMelding(feiler).build();
 
         doThrow(RuntimeException.class).when(tilsagnJsonMapper).pakkUtArenaMelding(tilsagnUnderBehandling);
-        tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
+        try {
+            tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tilsagnUnderBehandling);
+        } finally {
+            verify(tilsagnLoggRepository, never()).lagretIdHvisNyMelding(tilsagnUnderBehandling);
+            verify(tilsagnJsonMapper, never()).opprettTilsagn(any(TilsagnUnderBehandling.class));
+            verify(oppgaver, never()).utfoerOppgaver(any(TilsagnUnderBehandling.class));
+        }
 
-        verify(tilsagnLoggRepository, never()).lagretIdHvisNyMelding(tilsagnUnderBehandling);
-        verify(tilsagnJsonMapper, never()).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).oppdaterFeiletTilsagn(eq(tilsagnUnderBehandling), any(TilsagnException.class));
     }
 
-    @Test
-    public void avbryterHvisOpprettTilsagnFeiler() {
-        ArenaMelding feiler = Testdata.arenaMeldingMedFeil();
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().arenaMelding(feiler).build();
-
-        doNothing().when(tilsagnJsonMapper).pakkUtArenaMelding(tub);
-        doThrow(DataException.class).when(tilsagnJsonMapper).opprettTilsagn(tub);
-        when(tilsagnLoggRepository.lagretIdHvisNyMelding(tub)).thenReturn(true);
-        tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tub);
-
-        verify(tilsagnLoggRepository, atLeastOnce()).lagretIdHvisNyMelding(tub);
-        verify(tilsagnJsonMapper, times(1)).opprettTilsagn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).oppdaterFeiletTilsagn(eq(tub), any(TilsagnException.class));
-    }
-
-    @Test
-    public void avbryterHvisOpprettPdfDokFeiler() {
-        ArenaMelding arenaMelding = Testdata.arenaMelding();
-        TilsagnUnderBehandling tub = TilsagnUnderBehandling.builder().arenaMelding(arenaMelding).build();
-
-        doNothing().when(tilsagnJsonMapper).pakkUtArenaMelding(tub);
-        doNothing().when(tilsagnJsonMapper).opprettTilsagn(tub);
-        when(tilsagnLoggRepository.lagretIdHvisNyMelding(tub)).thenReturn(true);
-        doThrow(DataException.class).when(oppgaver).opprettPdfDok(tub);
-
-        tilsagnsbrevbehandler.behandleOgVerifisereTilsagn(tub);
-
-        verify(tilsagnLoggRepository, atLeastOnce()).lagretIdHvisNyMelding(tub);
-        verify(oppgaver, times(1)).opprettPdfDok(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).journalfoerTilsagnsbrev(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, never()).sendTilAltinn(any(TilsagnUnderBehandling.class));
-        verify(oppgaver, times(1)).oppdaterFeiletTilsagn(eq(tub), any(TilsagnException.class));
-    }
 }

--- a/src/test/java/no/nav/tag/tilsagnsbrev/integrasjon/TiltakTilsagnsbrevIntTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/integrasjon/TiltakTilsagnsbrevIntTest.java
@@ -4,8 +4,7 @@ import no.nav.tag.tilsagnsbrev.Testdata;
 import no.nav.tag.tilsagnsbrev.behandler.TilsagnLogg;
 import no.nav.tag.tilsagnsbrev.behandler.TilsagnLoggCrudRepository;
 import no.nav.tag.tilsagnsbrev.behandler.TilsagnLoggRepository;
-import no.nav.tag.tilsagnsbrev.behandler.TilsagnsbrevBehandler;
-import no.nav.tag.tilsagnsbrev.feilet.FeiletTilsagnsbrevRepository;
+import no.nav.tag.tilsagnsbrev.feilet.TilsagnsbrevRepository;
 import no.nav.tag.tilsagnsbrev.simulator.IntegrasjonerMockServer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -41,10 +40,7 @@ public class TiltakTilsagnsbrevIntTest {
     private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
 
     @Autowired
-    private TilsagnsbrevBehandler tilsagnsbrevbehandler;
-
-    @Autowired
-    private FeiletTilsagnsbrevRepository feiletTilsagnsbrevRepository;
+    private TilsagnsbrevRepository tilsagnsbrevRepository;
 
     @Autowired
     private TilsagnLoggCrudRepository loggCrudRepository;
@@ -81,7 +77,7 @@ public class TiltakTilsagnsbrevIntTest {
     @After
     public void tearDown() {
         mockServer.getServer().resetAll();
-        feiletTilsagnsbrevRepository.deleteAll();
+        tilsagnsbrevRepository.deleteAll();
         loggCrudRepository.deleteAll();
     }
 
@@ -94,27 +90,27 @@ public class TiltakTilsagnsbrevIntTest {
 
         assertTrue(tilsagnLoggRepository.tilsagnsbevIdFinnes(111));
         TilsagnLogg tilsagnLogg = loggCrudRepository.findAll().iterator().next();
-        assertFalse(feiletTilsagnsbrevRepository.existsById(tilsagnLogg.getId()));
+        assertFalse(tilsagnsbrevRepository.existsById(tilsagnLogg.getId()));
     }
 
     @Test
     public void feilVedUtpakkingAvArenaMelding() throws InterruptedException {
 
-        assertTrue(feiletTilsagnsbrevRepository.findAll().isEmpty());
+        assertTrue(tilsagnsbrevRepository.findAll().isEmpty());
         assertFalse(loggCrudRepository.findAll().iterator().hasNext());
 
         final String arenameldingMedFeil = Testdata.hentFilString("arenaMelding_som_feiler.json");
         kafkaTemplate.send(ArenaConsumer.topic, "", arenameldingMedFeil);
         Thread.sleep(SLEEP_LENGTH);
 
-        assertTrue("feil-database",feiletTilsagnsbrevRepository.findAll().isEmpty());
+        assertTrue("feil-database",tilsagnsbrevRepository.findAll().isEmpty());
         assertTrue("logg-database", loggCrudRepository.findAll().isEmpty());
     }
 
     @Test
     public void enFeilOgEnOkArenaMelding() throws InterruptedException {
 
-        assertTrue(feiletTilsagnsbrevRepository.findAll().isEmpty());
+        assertTrue(tilsagnsbrevRepository.findAll().isEmpty());
         assertTrue(loggCrudRepository.findAll().isEmpty());
 
         final String arenameldingMedFeil = Testdata.hentFilString("arenaMelding_som_feiler.json");
@@ -123,7 +119,7 @@ public class TiltakTilsagnsbrevIntTest {
         kafkaTemplate.send(ArenaConsumer.topic, "", arenameldingOk);
         Thread.sleep(SLEEP_LENGTH);
 
-        assertTrue("feil-database",feiletTilsagnsbrevRepository.findAll().isEmpty());
+        assertTrue("feil-database",tilsagnsbrevRepository.findAll().isEmpty());
 
         TilsagnLogg tilsagnLogg = loggCrudRepository.findAll().get(0);
         assertEquals(111 , tilsagnLogg.getTilsagnsbrevId().intValue());


### PR DESCRIPTION
Forsøker å forenkle litt sånn at tiltakene behandles på samme måte både når de kommer inn fra Kafka første gang og når de kjøres om igjen ved feil. Jeg tror dette er en stor fordel, fordi
- Koden som utfører oppgavene (lag pdf, journalfør, send til AltInn) blir helt lik i begge tilfeller. Jeg har flyttet all denne koden til `Oppgaver`-klassen og gjort de andre enkeltmetodene for hvert steg i prosessen private inne i `Oppgaver`. Alle testene for stegene i prosessen er også flyttet til en ny testklasse, `OppgaverTest`
- Alle tilsagn lagres i databasen på samme måte enten de har gått OK eller feilet. Tidligere ville bare tilsagn som var feilet og de som var OK etter først å ha feilet bli lagret. Dette vil gjøre det enklere å finne informasjon om alle tilsagnene, som journalpostid, altinn-id osv.
- Enklere flyt, siden det ikke er spesialhåndtering av "send til AltInn selv om journalføring feiler" for nye dokumenter.

Ulemper er at vi vil lagre mer data i databasen, siden vi nå vil ta vare på data for alle tilsagn. Hvis dette blir problematisk kan vi f.eks. løse det ved en ryddejobb som fjerner vellykkede tilsagn etter en viss tid. I tillegg mister vi funksjonaliteten som sender til AltInn dersom journalføring feiler. Dette kan vi gjeninnføre hvis vi ønsker det, men da kan det like godt innføres både ved førstegangskjøring og ved rekjøring. Hvis det er ønskelig å sende til Altinn selv om joark feiler kan vi også vurdere å endre rekkefølgen, så vi sender til Altinn før vi journalfører.