### PR TITLE
Vær eksplisitt på at datafeil ikke skal rekjøres

### DIFF
--- a/src/main/java/no/nav/tag/tilsagnsbrev/dto/tilsagnsbrev/TilsagnUnderBehandling.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/dto/tilsagnsbrev/TilsagnUnderBehandling.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import no.nav.tag.tilsagnsbrev.dto.ArenaMelding;
-import no.nav.tag.tilsagnsbrev.exception.DataException;
-import no.nav.tag.tilsagnsbrev.exception.TilsagnException;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -21,7 +19,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class TilsagnUnderBehandling {
 
-    public static final int MAX_RETRIES = 3;
+    static final int MAX_RETRIES = 3;
 
     @Id
     private UUID cid;
@@ -30,7 +28,7 @@ public class TilsagnUnderBehandling {
     @Builder.Default
     private int retry = 0;
     @Builder.Default
-    boolean datafeil = false;
+    private boolean datafeil = false;
     @Builder.Default
     private boolean behandlet = false; //Logisk sletting inntil videre
 
@@ -59,17 +57,11 @@ public class TilsagnUnderBehandling {
     }
 
     public boolean skalRekjoeres(){
-        return this.retry < MAX_RETRIES;
+        return !this.datafeil && this.retry < MAX_RETRIES;
     }
 
     public boolean manglerPdf(){
         return this.pdf == null;
-    }
-
-    public void setRetry(TilsagnException te){
-        if(te instanceof DataException){
-            retry = MAX_RETRIES;
-        }
     }
 
     public void increaseRetry(){

--- a/src/main/java/no/nav/tag/tilsagnsbrev/exception/DataException.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/exception/DataException.java
@@ -1,13 +1,6 @@
 package no.nav.tag.tilsagnsbrev.exception;
 
-import lombok.Data;
-
-import static no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev.TilsagnUnderBehandling.MAX_RETRIES;
-
-@Data
 public class DataException extends TilsagnException {
-
-    private final int retry = MAX_RETRIES;
 
     public DataException(String errMsg) {
         super(errMsg, true);

--- a/src/main/java/no/nav/tag/tilsagnsbrev/exception/SystemException.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/exception/SystemException.java
@@ -1,8 +1,5 @@
 package no.nav.tag.tilsagnsbrev.exception;
 
-import lombok.Getter;
-
-@Getter
 public class SystemException extends TilsagnException {
 
     public SystemException(String errMsg) {

--- a/src/main/java/no/nav/tag/tilsagnsbrev/feilet/FeiletTilsagnBehandler.java
+++ b/src/main/java/no/nav/tag/tilsagnsbrev/feilet/FeiletTilsagnBehandler.java
@@ -23,9 +23,7 @@ public class FeiletTilsagnBehandler {
 
     public boolean lagreEllerOppdaterFeil(TilsagnUnderBehandling tilsagnUnderBehandling, Exception e) {
         if (e instanceof TilsagnException) {
-            TilsagnException te = (TilsagnException) e;
-            tilsagnUnderBehandling.setRetry(te);
-            tilsagnUnderBehandling.setDatafeil(te.isDatafeil());
+            tilsagnUnderBehandling.setDatafeil(((TilsagnException) e).isDatafeil());
             return lagreEllerOppdater(tilsagnUnderBehandling);
         }
         return false;

--- a/src/test/java/no/nav/tag/tilsagnsbrev/dto/tilsagnsbrev/TilsagnUnderBehandlingTest.java
+++ b/src/test/java/no/nav/tag/tilsagnsbrev/dto/tilsagnsbrev/TilsagnUnderBehandlingTest.java
@@ -1,0 +1,25 @@
+package no.nav.tag.tilsagnsbrev.dto.tilsagnsbrev;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class TilsagnUnderBehandlingTest {
+
+    @Test
+    public void skalReskjores_returnerer_false_hvis_datafeil() {
+        assertThat(TilsagnUnderBehandling.builder().datafeil(true).build().skalRekjoeres(), is(false));
+    }
+
+    @Test
+    public void skalReskjores_returnerer_false_hvis_antall_er_storre_eller_lik_maks() {
+        assertThat(TilsagnUnderBehandling.builder().datafeil(false).retry(TilsagnUnderBehandling.MAX_RETRIES).build().skalRekjoeres(), is(false));
+    }
+
+    @Test
+    public void skalReskjores_returnerer_true_hvis_ikke_datafeil_og_antall_er_mindre_enn_maks() {
+        assertThat(TilsagnUnderBehandling.builder().datafeil(false).retry(TilsagnUnderBehandling.MAX_RETRIES - 1).build().skalRekjoeres(), is(true));
+    }
+
+}


### PR DESCRIPTION
Er eksplisitt på at datafeil ikke skal rekjøres, i stedet for å late som vi har forsøkt å rekjøre maks antall ganger. Da unngår vi at retries-telleren får en dobbel betydning, og vi unngår at tilsagn med datafeil plutselig blir rekjørt dersom vi justerer `MAX_RETRIES`-innstillingen senere. 
